### PR TITLE
do not mix contacts in groups and groupchat when adding new roster item.

### DIFF
--- a/source/contacts/RosterController.cpp
+++ b/source/contacts/RosterController.cpp
@@ -642,7 +642,7 @@ bool RosterController::appendToRosterIfNotAlreadyIn(const QString& jid)
     {
         QXmppRosterIq::Item item = rosterManager_->getRosterEntry(jid);
 
-        rosterList_.append(new RosterItem(jid, item.name(), RosterItem::SUBSCRIPTION_NONE, item.groups().size()>0, this));
+        rosterList_.append(new RosterItem(jid, item.name(), RosterItem::SUBSCRIPTION_NONE, false, this));
         return true; // entry added
     }
     else


### PR DESCRIPTION
Hi,

First of all, thanks for revitalizing the efforts around shmoose, I contributed a little bit in the past but the limitations of swiften and lack of time to manage do properly build the omemo version prevented me for a while.

I tried shmong and I see every contact is a groupchat, this is a bit weird, I think this is due to a line in the contacts update that check (if I'm not mistaken) if a contact is in roster group(s) to set the groupchat flag.

This call should only happen for a regular contact I think, and the flag can be set to false, groupchats are added in another path.

I'm not sure how things worked until now, maybe that's something that only happen with a new account.

Regards,